### PR TITLE
Changed date format on post to match home page

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -11,7 +11,7 @@
         <header class="post-header">
             <h1 class="post-title small-11 columns small-centered text-center" itemprop="headline">{{{title}}}</h1>
             <section class="post-meta text-center">
-                <p>Published <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}" itemprop="datePublished">{{date format="DD MMMM YYYY"}}</time> by {{author}}</p>
+                <p>Published <time class="post-date" datetime="{{date format='MMMM-Do-YYYY'}}" itemprop="datePublished">{{date format="MMMM Do YYYY"}}</time> by {{author}}</p>
                 <p>
                     {{#foreach tags}}
                         <a class="label" href="{{@blog.url}}/tag/{{slug}}">{{name}}</a>


### PR DESCRIPTION
I noticed that the date format on the home page doesn't match the date format on the post. If this is not intentional, then I offer up this PR. 