### PR TITLE
Upgrading the template to Ghost 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-![Ghost Compatability](https://img.shields.io/badge/Compatible%20with%20Ghost-v0.5.10-brightgreen.svg)
-
-no-nonsense
+Compatible with Ghost 1.0 and +
 ===========
 
 

--- a/author.hbs
+++ b/author.hbs
@@ -4,10 +4,10 @@
 {{navigation}}
 
 <section class="author-profile inner">
-    {{#if author.image}}
+    {{#if author.profile_image}}
 	    <div class="row">
 		    <figure class="small-8 columns author-image">
-		        <div class="img" style="background-image: url({{author.image}})">
+		        <div class="img" style="background-image: url({{author.profile_image}})">
 		        </div>
 		    </figure>
 	    </div>

--- a/default.hbs
+++ b/default.hbs
@@ -11,8 +11,6 @@
         {{#post}}
             <meta name="description" content="{{excerpt words=50}}" />
         {{/post}}
-    {{else}}
-        <meta name="description" content="{{meta_description}}" />
     {{/if}}
 
     <meta name="HandheldFriendly" content="True" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "no-nonsense",
-  "version": "0.2.2",
+  "version": "0.2.3",
+  "author": {"email": "mihnea@linux.com"},
+  "config": { "posts_per_page": 5},
   "devDependencies": {
     "del": "^0.1.1",
     "gulp": "^3.8.6",

--- a/post.hbs
+++ b/post.hbs
@@ -18,8 +18,8 @@
                     {{/foreach}}
                 </p>
             </section>
-            {{#if image}}
-                <img src="{{image}}" class="post-img">
+            {{#if feature_image}}
+                <img src="{{img_url feature_image}}" class="post-img">
             {{/if}}
         </header>
 


### PR DESCRIPTION
Using the https://gscan.ghost.org/ interface, fixed all the rules that were broken. 